### PR TITLE
Implemented batch upload feature using file_uploadV2 functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ the ```102CANON``` folder would be selected throgh the web pages file selection.
 - A UI feature that will display the uploaded photos in a grid as they are uploaded, and allow users to view details, download specific images, and delete images from a channel.
 - Optional authentification to limit use to those within organization.
 - Authentication method to prevent abuse from client side.
+- Option to decide what comment will accompany each message.
 
 ## Contributing
 Contributions are welcome! If you would like to contribute to this project, please follow these steps:

--- a/backend/Controllers/api.controllers.ts
+++ b/backend/Controllers/api.controllers.ts
@@ -1,8 +1,6 @@
 import express from 'express';
 import SlackBot from '../Models/slackbot';
 
-
-
 export const getChannels = async (request: express.Request, response: express.Response) => {
     try {
         const slackbot = new SlackBot();
@@ -25,7 +23,7 @@ export const getChannels = async (request: express.Request, response: express.Re
 
     const slackbot = new SlackBot(dirName, channel);
     try {
-         await slackbot.processFilesAndUpload();
+         await slackbot.processFilesAndUpload(14); // Arg is max amount of images to send in one message (Slack currently uploads 14 max)
         response.status(200).json({ message: 'Files Uploaded Successfully!' });
     } catch (error) {
         console.error(`Error uploading files: ${error}`);


### PR DESCRIPTION
- Instead of iterating over the sorted array of file names and upload the file paths 1 by one, we create an array "file_uploads" that contain objects with the structure:

`{
file: //some/file/path.ext
filename: "some file name"
}`
We iterate through the array, creating a new object with file and filename with each pass.
- The `processFilesAndUpload` function has an optional argument of how many files to upload in a message. By default it is 10, but current the limit is 14 files per message via Slack's API (tested experimentally)
- Th "initial comment field will be set to the current date (with format DayOfWeek, Month Day, Year)