### PR TITLE
Files now write to /tmp storage

### DIFF
--- a/backend/src/Controllers/api.controllers.ts
+++ b/backend/src/Controllers/api.controllers.ts
@@ -32,15 +32,10 @@ export const uploadFiles = async (req: express.Request, res: express.Response) =
   const form = new IncomingForm() as any;
 
   // Formidable config
-  form.uploadDir = path.join(__dirname, '../uploads');
+  form.uploadDir = '/tmp';
   form.keepExtensions = true;
   form.maxFileSize = 50 * 1024 * 1024; // 50MB
-
-  // Check upload folder, create if not present
-  if (!fs.existsSync(form.uploadDir)) {
-    fs.mkdirSync(form.uploadDir, { recursive: true });
-  }
-
+  
   form.parse(req, async (err: Error, fields: FormFields, files: { [key: string]: File }) => {
     if (err) {
       console.error(`Error processing upload: ${err}`);


### PR DESCRIPTION
Files will now write to and be uploaded to slack from /tmp directory on server. Also removed check for upload directory since /tmp always exists.