### PR TITLE
Changed max for batch uploaded instead of individual files

### DIFF
--- a/backend/src/Controllers/api.controllers.ts
+++ b/backend/src/Controllers/api.controllers.ts
@@ -34,7 +34,8 @@ export const uploadFiles = async (req: express.Request, res: express.Response) =
   // Formidable config
   form.uploadDir = '/tmp';
   form.keepExtensions = true;
-  form.maxFileSize = 400 * 1024 * 1024; // 400MB
+  form.maxFileSize = 400 * 1024 * 1024; // 400MB, for individual files
+  form.maxTotalFileSize = 400 * 1024 * 1024; // 400MB, for all files in a batch
   
   form.parse(req, async (err: Error, fields: FormFields, files: { [key: string]: File }) => {
     if (err) {


### PR DESCRIPTION
#28 This commit increased the maximum size limit for each individual file that was uploaded, but what need to be increased was the total size allowed for batch uploaded file, which also defaults to 200mb. Increased it to 400 mb
<img width="1066" alt="Screenshot 2024-02-05 at 9 01 40 PM" src="https://github.com/OODemi52/slackUpload/assets/76265069/47318aa7-d018-4d08-8995-5b730a9490b2">
