### PR TITLE
Moved deletion of files to Slackbot file

### DIFF
--- a/backend/src/Controllers/api.controllers.ts
+++ b/backend/src/Controllers/api.controllers.ts
@@ -58,17 +58,6 @@ export const uploadFiles = async (req: express.Request, res: express.Response) =
   
     try {
       await slackbot.batchAndUploadFiles(uploadedFiles, 14);
-
-      uploadedFiles.forEach((file: { path: fs.PathLike; }) => {
-        fs.unlink(file.path, unlinkErr => {
-          if (unlinkErr) {
-            console.error(`Error deleting file ${file.path}: ${unlinkErr}`);
-          } else {
-            console.log(`Successfully deleted file ${file.path}`);
-          }
-        });
-      });
-
       res.status(200).json({ message: 'Files uploaded successfully!' });
     } catch (error) {
       console.error(`Error uploading files: ${error}`);

--- a/backend/src/Models/slackbot.ts
+++ b/backend/src/Models/slackbot.ts
@@ -1,4 +1,5 @@
 import * as dotenv from 'dotenv';
+import fs from 'fs';
 import { WebClient } from '@slack/web-api';
 
 dotenv.config();
@@ -38,25 +39,40 @@ export default class SlackBot {
     }
   }
 
+  async deletionPromises(uploadedFiles: UploadedFile[]): Promise<void[]> {
+    const deletionPromises = uploadedFiles.map((file: UploadedFile) =>
+      fs.promises.unlink(file.path).then(() => {
+        console.log(`Successfully deleted file ${file.path}`);
+      }).catch((unlinkErr) => {
+        console.error(`Error deleting file ${file.path}: ${unlinkErr}`);
+      })
+    );
+
+    return Promise.all(deletionPromises);
+  }
+
   async batchAndUploadFiles(uploadedFiles: UploadedFile[], message_length: number): Promise<void> {
     const sortedFiles = uploadedFiles.sort((a, b) => {
       return a.name.localeCompare(b.name, undefined, { numeric: true, sensitivity: 'base' });
     });
-  
-    const files_upload: { filename: string, file: string }[] = [];
-  
-    for (let i = 0; i < sortedFiles.length; i++) {
-      const filename: string = sortedFiles[i].name;
-      const file: string = sortedFiles[i].path;
-  
-      files_upload.push({ file, filename });
-      console.log('Files to upload:', files_upload);
-  
-      if ((i + 1) % message_length === 0 || i === sortedFiles.length - 1) {
-        await this.uploadFilesToSlackChannel(files_upload);
-        files_upload.length = 0;
-      }
+
+    const totalBatches = Math.ceil(sortedFiles.length / message_length);
+
+    for (let i = 0; i < sortedFiles.length; i += message_length) {
+      const batchFiles = sortedFiles.slice(i, i + message_length);
+      const files_upload = batchFiles.map(file => ({
+        filename: file.name,
+        file: file.path
+      }));
+
+      const batchNumber = Math.floor(i / message_length) + 1;
+      console.log(`Preparing batch ${batchNumber} out of ${totalBatches} for upload. Files to upload:`, files_upload);
+
+      await this.uploadFilesToSlackChannel(files_upload);
+      await this.deletionPromises(batchFiles);
     }
+
+    console.log(`All files uploaded to Slack`);
   }
   
   private async uploadFilesToSlackChannel(file_uploads: { filename: string, file: string }[]): Promise<void> {


### PR DESCRIPTION
#33 Previous commit did not resolve the issue, have moved the deletion of files to the slack bot to ensure that they happen right after and upload is completed to free space between uploads. Also utilized Promise.all to ensure that the deletion completes before the program moves on. Also modified error handling a bit to ensure better readability in server logs